### PR TITLE
Enable RSS feed generation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,9 @@ highlight_code = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
+# Generate RSS feed
+generate_rss = true
+
 [link_checker]
 skip_prefixes = [
     "https://crates.io/crates", # see https://github.com/rust-lang/crates.io/issues/788


### PR DESCRIPTION
I see the feed is linked in the `<head>` but I think this is needed to make Zola generate it. 