### PR TITLE
Change rust-osdev.com to rust-osdev.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homepage
 
-This repository contains the source code for our organization homepage at <https://rust-osdev.com>.
+This repository contains the source code for our organization homepage at <https://rust-osdev.org>.
 
 ## License
 

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 # The URL the site will be built for
-base_url = "https://rust-osdev.com"
+base_url = "https://rust-osdev.org"
 
 title = "Rust OSDev"
 description = "Operating System Development in Rust"

--- a/content/this-month/2020-04.md
+++ b/content/this-month/2020-04.md
@@ -109,7 +109,7 @@ The [`uefi` crate](https://github.com/rust-osdev/uefi-rs) provides abstractions 
 
 There are a number of new projects in the `rust-osdev` organization:
 
-- [**`homepage`:**](https://github.com/rust-osdev/homepage) As you might have noticed by now, we have a new organization-level homepage at <https://rust-osdev.com/>. The `homepage` repository contains the source code for this website. Right now, it is still a work-in-progress and only contains the very minimum to host this post, but we plan to add more content soon.
+- [**`homepage`:**](https://github.com/rust-osdev/homepage) As you might have noticed by now, we have a new organization-level homepage at <https://rust-osdev.org/>. The `homepage` repository contains the source code for this website. Right now, it is still a work-in-progress and only contains the very minimum to host this post, but we plan to add more content soon.
 
   Note that we will create a branch for the upcoming May issue of _"This Month in Rust OSDev"_. Please open pull requests for any content that you would like to see next month.
 - [**`vga`:**](https://github.com/rust-osdev/vga) The goal of the `vga` crate is to allow configuration of the VGA hardware. It already makes it possible to switch from a text-based buffer to a pixel-based framebuffer, which enables drawing of lines, geometric shapes, and even images. The library is created by [@RKennedy9064](https://github.com/RKennedy9064).

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,2 @@
+rust-osdev.org
 rust-osdev.com

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
     <link href="/css/poole.css" rel="stylesheet">
     <link href="/css/main.css" rel="stylesheet">
 
-    <link rel="alternate" type="application/rss+xml" title="RSS feed for rust-osdev.com" href="{{ config.base_url | safe }}/rss.xml" />
+    <link rel="alternate" type="application/rss+xml" title="RSS feed for rust-osdev.org" href="{{ config.base_url | safe }}/rss.xml" />
 
     <title>{% block title %}{% endblock title %}</title>
 </head>


### PR DESCRIPTION
@phil-opp 

I added two CNAME resolution records to rust-osdev.org, pointing to rust-osdev.com and rust-osdev.github.io.

If nothing goes wrong, after the merger, we can access this website through the .org domain name.