### PR TITLE
Fix download-artifact path

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -67,6 +67,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: generated_site
+        path: generated_site
 
     - name: Check out gh-pages branch
       uses: actions/checkout@v2


### PR DESCRIPTION
So, it seems the download-artifacts action has changed the default path.
Tested on my fork, it works well: https://github.com/JohnTitor/osdev-homepage/runs/938146137
I didn't notice this behavior, sorry!
r? @phil-opp 