### PR TITLE
March 2021: add changes for acpi crates, and potential new section

### DIFF
--- a/content/this-month/2021-03/index.md
+++ b/content/this-month/2021-03/index.md
@@ -108,6 +108,17 @@ the `acpi` and `aml` crates:
   This is important for supporting running on real hardware, which often assumes the existance of these objects.
   <span class="gray">(published as `aml v0.11.0`)</span>
 
+## Call for Participation
+Want to contribute to a Rust OSDev project, but don't know where to start? Pick up one of these outstanding
+issues in one of our projects and get started!
+
+If you maintain a Rust OSDev project and are looking for contributors, especially for tasks suited to people
+getting started in this space, please [create a PR](https://github.com/rust-osdev/homepage/pulls) against the
+`next` branch with the tasks you want to include in the next issue.
+
+- [(`acpi`) Record attempted conversion in `AmlError::IncompatibleValueConversion`](https://github.com/rust-osdev/acpi/issues/53)
+- [(`acpi`) Support the new MADT Multiprocessor Wakeup structure](https://github.com/rust-osdev/acpi/issues/87)
+
 ## Personal Projects
 
 In this section, we describe updates to personal projects that are not directly related to the `rust-osdev` organization. Feel free to [create a pull request](https://github.com/rust-osdev/homepage/pulls) with the updates of your OS project for the next post.

--- a/content/this-month/2021-03/index.md
+++ b/content/this-month/2021-03/index.md
@@ -105,7 +105,7 @@ the `acpi` and `aml` crates:
   is also technically a breaking change in `aml v0.11.0`.
 - The AML interpreter now correctly supplies the `\_OS`, `\_OSI`, and `\_REV` objects. These objects were designed
   to allow firmware to detect OS support for new AML features, but [come with a bit of baggage](https://www.kernel.org/doc/html/latest/firmware-guide/acpi/osi.html).
-  This is important for supporting running on real hardware, which often assumes the existance of these objects.
+  This is important for supporting running on real hardware, which often assumes the existence of these objects.
   <span class="gray">(published as `aml v0.11.0`)</span>
 
 ## Call for Participation


### PR DESCRIPTION
This adds changes for the acpi crates for March 2021.

It also adds a potential new section that I think could be neat: a 'Call for Participation' section with tasks from our projects that are suited to people looking to get involved. OSDev can be a particularly intimidating space for new contributors, so I think this could be nice, especially if maintainers are willing to mentor new contributors. I've just added a couple of easy tasks from `acpi`, but if other projects have stuff they want to add that would be great :)

Of course, if other people (cc @phil-opp) don't think this section is a good idea, I'm fine with removing it from this issue.