### PR TITLE
Add April changes for `uefi-rs`

### DIFF
--- a/content/this-month/2022-03/index.md
+++ b/content/this-month/2022-03/index.md
@@ -35,7 +35,7 @@ In this section, we give an overview of notable changes to the projects hosted u
 
 ### [`x86_64`](https://github.com/rust-osdev/x86_64)
 
-<span class="maintainers">Maintained by [@phil-opp](https://github.com/phil-opp), [@josephlr](https://github.com/orgs/rust-osdev/people/josephlr), [@Freax13](https://github.com/orgs/rust-osdev/people/Freax13), and [@rybot666](https://github.com/orgs/rust-osdev/people/rybot666)</span>
+<span class="maintainers">Maintained by [@phil-opp](https://github.com/phil-opp), [@josephlr](https://github.com/josephlr), [@Freax13](https://github.com/Freax13), and [@rybot666](https://github.com/rybot666)</span>
 
 The `x86_64` crate provides various abstractions for `x86_64` systems, including wrappers for CPU instructions, access to processor-specific registers, and abstraction types for architecture-specific structures such as page tables and descriptor tables.
 
@@ -92,7 +92,7 @@ Special thanks to our co-maintainer [@josephlr](https://github.com/josephlr), wh
 
 ### [`uefi-rs`](https://github.com/rust-osdev/uefi-rs)
 
-<span class="maintainers">Maintained by [@GabrielMajeri](https://github.com/GabrielMajeri) and [@nicholasbishop](https://github.com/orgs/rust-osdev/people/nicholasbishop)</span>
+<span class="maintainers">Maintained by [@GabrielMajeri](https://github.com/GabrielMajeri) and [@nicholasbishop](https://github.com/nicholasbishop)</span>
 
 The `uefi` crate provides safe and performant wrappers for [UEFI](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface), the successor to the BIOS.
 

--- a/content/this-month/2022-04/index.md
+++ b/content/this-month/2022-04/index.md
@@ -8,7 +8,8 @@ authors = [
     "phil-opp",
     "toku-sa-n",
     "phip1611",
-    "andre-richter"
+    "andre-richter",
+    "GabrielMajeri",
     # add yourself here
 ]
 +++
@@ -40,6 +41,39 @@ In this section, we give an overview of notable changes to the projects hosted u
 The `x86_64` crate provides various abstractions for `x86_64` systems, including wrappers for CPU instructions, access to processor-specific registers, and abstraction types for architecture-specific structures such as page tables and descriptor tables.
 
 In April, …
+
+### [`uefi-rs`](https://github.com/rust-osdev/uefi-rs)
+
+<span class="maintainers">Maintained by [@GabrielMajeri](https://github.com/GabrielMajeri) and [@nicholasbishop](https://github.com/nicholasbishop)</span>
+
+The `uefi` crate provides safe and performant wrappers for [UEFI](https://en.wikipedia.org/wiki/Unified_Extensible_Firmware_Interface), the successor to the BIOS.
+
+We merged the following changes in April:
+
+#### Features
+
+- [Add support to get the file path of loaded image](https://github.com/rust-osdev/uefi-rs/pull/398)
+- [Add `FilePathMediaDevicePath` (and a bunch of supporting code)](https://github.com/rust-osdev/uefi-rs/pull/404)
+- [Improve device path API](https://github.com/rust-osdev/uefi-rs/pull/421)
+
+#### Bug fixes
+
+- [Fix undefined behavior in `File::get_boxed_info`](https://github.com/rust-osdev/uefi-rs/pull/407)
+- [Fix potential undefined behavior in file info](https://github.com/rust-osdev/uefi-rs/pull/408)
+- [Fix `test_get_boxed_info` when `-Zmiri-tag-raw-pointers` is enabled](https://github.com/rust-osdev/uefi-rs/pull/415)
+- [Fix off-by-one test error](https://github.com/rust-osdev/uefi-rs/pull/422)
+
+#### CI and linting
+
+- [Enable the `clippy::ptr_as_ptr` lint](https://github.com/rust-osdev/uefi-rs/pull/410)
+
+#### Documentation improvements
+
+- [Add changelog entries for recent PRs](https://github.com/rust-osdev/uefi-rs/pull/405)
+- [Add documentation on why `UnsafeCell` is used for protocols](https://github.com/rust-osdev/uefi-rs/pull/409)
+- [Add documentation links for `BootServices` and `RuntimeServices`](https://github.com/rust-osdev/uefi-rs/pull/419)
+
+Thanks to [@supdrewin](https://github.com/supdrewin), [@nicholasbishop](https://github.com/nicholasbishop) and [@raccog](https://github.com/raccog) for their contributions!
 
 ### [`xhci`](https://github.com/rust-osdev/xhci)
 


### PR DESCRIPTION
This PR adds the April 2022 updates for the `uefi-rs` crate.

I've also fixed some links from last month's post (the crate maintainers were linked to `github.com/orgs/rust-osdev/people/<username>` instead of `github.com/<username>`, which isn't valid for people outside the org).