### PR TITLE
Add a redirect to the UEFI book

### DIFF
--- a/static/uefi-book/index.html
+++ b/static/uefi-book/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://rust-osdev.github.io/uefi-rs/HEAD/</title>
+<meta http-equiv="refresh" content="0; URL=https://rust-osdev.github.io/uefi-rs/HEAD/">
+<link rel="canonical" href="https://rust-osdev.github.io/uefi-rs/HEAD/">


### PR DESCRIPTION
As proposed in https://github.com/rust-osdev/uefi-rs/pull/515#issuecomment-1272345850.