### PR TITLE
fixed typo: structires -> structures

### DIFF
--- a/content/this-month/2022-04/index.md
+++ b/content/this-month/2022-04/index.md
@@ -162,7 +162,7 @@ Thanks to [@hawkw](https://github.com/hawkw) for this contribution!
 
 <span class="maintainers">Maintained by [@toku-sa-n](https://github.com/toku-sa-n)</span>
 
-The `xhci` crate provides types of xHCI structires, such as Registers and TRBs.
+The `xhci` crate provides types of xHCI structures, such as Registers and TRBs.
 
 In this month, we released a new version 0.8.3 which includes [a bug fix](https://github.com/rust-osdev/xhci/pull/132) reported and committed by [@Yuna-Tomi](https://github.com/Yuna-Tomi). The bug was that `EventRingDequeuePointerRegister::event_ring_dequeue_pointer()` did not return the correct address. Thanks for the contribution!.
 

--- a/content/this-month/2022-05/index.md
+++ b/content/this-month/2022-05/index.md
@@ -80,7 +80,7 @@ Thanks to [@alesharik](https://github.com/alesharik) for this contribution!
 
 <span class="maintainers">Maintained by [@toku-sa-n](https://github.com/toku-sa-n)</span>
 
-The `xhci` crate provides types of xHCI structires, such as Registers and TRBs.
+The `xhci` crate provides types of xHCI structures, such as Registers and TRBs.
 
 We merged the following fix this month:
 

--- a/content/this-month/2022-07/index.md
+++ b/content/this-month/2022-07/index.md
@@ -64,7 +64,7 @@ Thanks to [@Zildj1an](https://github.com/Zildj1an) for their contribution!
 
 <span class="maintainers">Maintained by [@toku-sa-n](https://github.com/toku-sa-n)</span>
 
-The `xhci` crate provides types of xHCI structires, such as Registers and TRBs.
+The `xhci` crate provides types of xHCI structures, such as Registers and TRBs.
 
 We merged the following changes this month:
 

--- a/content/this-month/2022-08/index.md
+++ b/content/this-month/2022-08/index.md
@@ -113,7 +113,7 @@ Thanks to [@evanrichter](https://github.com/evanrichter) for reporting this vuln
 
 <span class="maintainers">Maintained by [@toku-sa-n](https://github.com/toku-sa-n)</span>
 
-The `xhci` crate provides types of xHCI structires, such as Registers and TRBs.
+The `xhci` crate provides types of xHCI structures, such as Registers and TRBs.
 
 We merged the following changes this month:
 

--- a/content/this-month/2022-09/index.md
+++ b/content/this-month/2022-09/index.md
@@ -100,7 +100,7 @@ Thanks to [@ColinFinck](https://github.com/ColinFinck) for their contribution!
 
 <span class="maintainers">Maintained by [@toku-sa-n](https://github.com/toku-sa-n)</span>
 
-The `xhci` crate provides types of xHCI structires, such as Registers and TRBs.
+The `xhci` crate provides types of xHCI structures, such as Registers and TRBs.
 
 We merged the following changes in September:
 


### PR DESCRIPTION
Fixed this type that's been irritating me for some time...