### PR TITLE
Update to zola 0.16.1

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.12.2/zola-v0.12.2-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
 
     - name: "Build Site"
       run: ./zola build
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: 'Download Zola'
-      run: curl -sL https://github.com/getzola/zola/releases/download/v0.12.2/zola-v0.12.2-x86_64-unknown-linux-gnu.tar.gz | tar zxv
+      run: curl -sL https://github.com/getzola/zola/releases/download/v0.16.1/zola-v0.16.1-x86_64-unknown-linux-gnu.tar.gz | tar zxv
 
     - name: "Run zola check"
       run: ./zola check

--- a/content/this-month/2020-12/index.md
+++ b/content/this-month/2020-12/index.md
@@ -16,7 +16,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we will 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our new [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our new <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (December 2020)" post.

--- a/content/this-month/2021-01/index.md
+++ b/content/this-month/2021-01/index.md
@@ -14,7 +14,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we will 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (January 2021)" post.

--- a/content/this-month/2021-02/index.md
+++ b/content/this-month/2021-02/index.md
@@ -14,7 +14,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (February 2021)" post.

--- a/content/this-month/2021-03/index.md
+++ b/content/this-month/2021-03/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 ## Project Updates
 

--- a/content/this-month/2021-04/index.md
+++ b/content/this-month/2021-04/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (April 2021)" post.

--- a/content/this-month/2021-05/index.md
+++ b/content/this-month/2021-05/index.md
@@ -17,7 +17,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (May 2021)" post.

--- a/content/this-month/2021-06/index.md
+++ b/content/this-month/2021-06/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (June 2021)" post.

--- a/content/this-month/2021-07/index.md
+++ b/content/this-month/2021-07/index.md
@@ -16,7 +16,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (July 2021)" post.

--- a/content/this-month/2021-08/index.md
+++ b/content/this-month/2021-08/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (August 2021)" post.

--- a/content/this-month/2021-09/index.md
+++ b/content/this-month/2021-09/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (September 2021)" post.

--- a/content/this-month/2021-10/index.md
+++ b/content/this-month/2021-10/index.md
@@ -16,7 +16,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (October 2021)" post.

--- a/content/this-month/2021-11/index.md
+++ b/content/this-month/2021-11/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (November 2021)" post.

--- a/content/this-month/2021-12/index.md
+++ b/content/this-month/2021-12/index.md
@@ -17,7 +17,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (December 2021)" post.

--- a/content/this-month/2022-01/index.md
+++ b/content/this-month/2022-01/index.md
@@ -16,7 +16,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (January 2022)" post.

--- a/content/this-month/2022-02/index.md
+++ b/content/this-month/2022-02/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (February 2022)" post.

--- a/content/this-month/2022-03/index.md
+++ b/content/this-month/2022-03/index.md
@@ -17,7 +17,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (March 2022)" post.

--- a/content/this-month/2022-04/index.md
+++ b/content/this-month/2022-04/index.md
@@ -19,7 +19,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (April 2022)" post.

--- a/content/this-month/2022-05/index.md
+++ b/content/this-month/2022-05/index.md
@@ -14,7 +14,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (May 2022)" post.

--- a/content/this-month/2022-06/index.md
+++ b/content/this-month/2022-06/index.md
@@ -15,7 +15,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (June 2022)" post.

--- a/content/this-month/2022-07/index.md
+++ b/content/this-month/2022-07/index.md
@@ -14,7 +14,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (July 2022)" post.

--- a/content/this-month/2022-08/index.md
+++ b/content/this-month/2022-08/index.md
@@ -11,7 +11,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (August 2022)" post.

--- a/content/this-month/2022-09/index.md
+++ b/content/this-month/2022-09/index.md
@@ -11,7 +11,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (September 2022)" post.

--- a/content/this-month/2022-10/index.md
+++ b/content/this-month/2022-10/index.md
@@ -11,7 +11,7 @@ Welcome to a new issue of _"This Month in Rust OSDev"_. In these posts, we give 
 
 <!-- more -->
 
-This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our [_comment form_](#comment-form) at the bottom of this page.
+This series is openly developed [on GitHub](https://github.com/rust-osdev/homepage/). Feel free to open pull requests there with content you would like to see in the next issue. If you find some issues on this page, please report them by [creating an issue](https://github.com/rust-osdev/homepage/issues/new) or using our <a href="#comment-form">_comment form_</a> at the bottom of this page.
 
 <!--
     This is a draft for the upcoming "This Month in Rust OSDev (October 2022)" post.


### PR DESCRIPTION
~~This fixes the CI error about a `Virtio` link, which I think was just a CA cert issue.~~ It introduced a bunch of new errors though on the the links to the comment form. I replaced those with HTML-style links so that zola ignores them, and that seems to work fine.