### PR TITLE
Fix link-check error on linux-kvm.org

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,7 @@ skip_prefixes = [
     "https://crates.io/crates", # see https://github.com/rust-lang/crates.io/issues/788
     "https://github.com", # because of rate limiting
     "https://rusty-hermit.k8s.eonerc.rwth-aachen.de/", # RustyHermit show case
+    "https://www.linux-kvm.org", # see https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
 ]
 
 [extra]


### PR DESCRIPTION
I think this is due to
https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/. I've attempted to contact someone who might be able to help fix linux-kvm.org to avoid this error, but for now just skip checking that link. It works fine in a browser.