### PR TITLE
Add efs library

### DIFF
--- a/content/this-month/2024-04/index.md
+++ b/content/this-month/2024-04/index.md
@@ -82,7 +82,25 @@ In this section, we describe updates to Rust OS projects that are not directly r
     ...<<your project updates>>...
 -->
 
-<span class="gray">No projects updates were submitted this month.</span>
+### [RatCornu/efs](https://codeberg.org/RatCornu/efs)
+
+[`efs`](https://crates.io/efs) is a recently published `no-std` library which provides an OS and architecture independent implementation of some UNIX filesystems in Rust.
+
+Currently only the [ext2 filesystem](https://fr.wikipedia.org/wiki/Ext2) is directly implemented, but I will soonly work on other filesystems!
+
+It's still young so it may contain bugs, but it's hugely tested so that it does not happen.
+
+Some of the features provided :
+
+* `no_std` support (enabled by default)
+
+* General interface for UNIX files and filesystems
+
+* `read/write` regular files
+
+* retrieve, add and remove directory entries directly from a path and a current working directory.
+
+I hope you will find this useful! If you have any remark, idea or issue, do not hesitate to submit an issue!
 
 ## Join Us?
 


### PR DESCRIPTION
Hello!

I published a new release of [efs](http://codeberg.org/RatCornu/efs), a `no_std` library for UNIX filesystems. I think it's worth sharing as it can be useful for people wanting a general interface for fs, or who wants a Rust ext2 implementation.

Thanks!