### PR TITLE
Add Miralis to newletter

### DIFF
--- a/content/this-month/2025-05/index.md
+++ b/content/this-month/2025-05/index.md
@@ -44,6 +44,7 @@ In this section, we collect recent updates to `rustc`, `cargo`, and other toolin
   - (optional) Some additional context
 -->
 
+- [Miralis, a RISC-V virtual firmware monitor](https://github.com/CharlyCst/miralis)
 
 ## `rust-osdev` Projects
 


### PR DESCRIPTION
Miralis is a research project I worked on for the past year, it is a RISC-V firmware that virtualizes RISC-V firmware. A bit like a hypervisor is a kernel that virtualizes kernels.
I just published the v0.1 release this month, with support for 2 hardware platforms, so it seems like a good time to share the project :)

