### PR TITLE
Add Open Nexus OS August 2026 update

### DIFF
--- a/content/this-month/2026-08/index.md
+++ b/content/this-month/2026-08/index.md
@@ -86,7 +86,16 @@ In this section, we describe updates to Rust OS projects that are not directly r
     ...<<your project updates>>...
 -->
 
-<span class="gray">No project updates were submitted this month.</span>
+### [`open-nexus-OS/open-nexus-OS`](https://github.com/open-nexus-OS/open-nexus-OS)
+<span class="maintainers">(Section written by [@JenningSchaefer](https://github.com/JenningSchaefer))</span>
+
+[Open Nexus OS](https://github.com/open-nexus-OS/open-nexus-OS) is a capability-based microkernel operating system written in Rust and targeting RISC-V.
+
+This month, the Open Nexus graphical desktop stack reached a major milestone: its declarative UI DSL is now driving a working desktop interface. The `.nx` UI definitions and `.nxtheme` design tokens are used to implement the actual interface, allowing the desktop UI to be built from the same declarative system used to define its design.
+
+The desktop stack includes a compositor, window manager, launcher, and UI components running on top of the Open Nexus userspace architecture. The project also includes a boot-to-desktop demonstration showing the graphical environment running in QEMU.
+
+[Repository](https://github.com/open-nexus-OS/open-nexus-OS) · [Demo video](https://www.youtube.com/watch?v=Vrf6Z1sAY5I)
 
 
 

--- a/content/this-month/2026-08/index.md
+++ b/content/this-month/2026-08/index.md
@@ -87,15 +87,15 @@ In this section, we describe updates to Rust OS projects that are not directly r
 -->
 
 ### [`open-nexus-OS/open-nexus-OS`](https://github.com/open-nexus-OS/open-nexus-OS)
-<span class="maintainers">(Section written by [@JenningSchaefer](https://github.com/JenningSchaefer))</span>
+<span class="maintainers">(Section written by [@jenningschaefer](https://github.com/jenningschaefer))</span>
 
-[Open Nexus OS](https://github.com/open-nexus-OS/open-nexus-OS) is a capability-based microkernel operating system written in Rust and targeting RISC-V.
+[Open Nexus OS](https://open-nexus-os.io/) is a capability-based microkernel operating system written in Rust and targeting RISC-V.
 
 This month, the Open Nexus graphical desktop stack reached a major milestone: its declarative UI DSL is now driving a working desktop interface. The `.nx` UI definitions and `.nxtheme` design tokens are used to implement the actual interface, allowing the desktop UI to be built from the same declarative system used to define its design.
 
 The desktop stack includes a compositor, window manager, launcher, and UI components running on top of the Open Nexus userspace architecture. The project also includes a boot-to-desktop demonstration showing the graphical environment running in QEMU.
 
-[Repository](https://github.com/open-nexus-OS/open-nexus-OS) · [Demo video](https://www.youtube.com/watch?v=Vrf6Z1sAY5I)
+[Website](https://open-nexus-os.io/) · [Repository](https://github.com/open-nexus-OS/open-nexus-OS) · [Demo video](https://www.youtube.com/watch?v=Vrf6Z1sAY5I)
 
 
 


### PR DESCRIPTION
This adds an August 2026 update for Open Nexus OS to the "Other Projects" section.

The update focuses on the new graphical desktop stack and its declarative UI DSL running on the Open Nexus Rust/RISC-V operating system.
